### PR TITLE
fix: less aggresive retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Octobud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1]
+
+### Added
+### Changed
+
+- Less aggressive retrying when syncing, now respecting rate limit headers if present.
+
+### Deprecated
+### Removed
+### Fixed
+
 ## [0.2.0]
 
 ### Added

--- a/backend/internal/github/client.go
+++ b/backend/internal/github/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,11 +36,44 @@ const (
 	minPerPage        = 10 // Minimum page size for retries
 	githubAPIBase     = "https://api.github.com"
 	githubGraphQLBase = "https://api.github.com/graphql"
+
+	// HTTP header names for rate limiting
+	headerRetryAfter     = "Retry-After"
+	headerRateLimitReset = "X-RateLimit-Reset"
 )
 
 // retryPageSizes defines the page sizes to try when encountering 502/504 errors.
 // These are progressively smaller to help with timeout issues.
 var retryPageSizes = []int{25, 15, minPerPage}
+
+// newAPIError creates an APIError with retry timing information parsed from headers.
+// This takes only the required fields rather than the full http.Response for testability.
+func newAPIError(statusCode int, headers http.Header, body []byte) *APIError {
+	apiErr := &APIError{
+		StatusCode: statusCode,
+		Message:    string(body),
+	}
+
+	// Parse Retry-After header (integer seconds)
+	// GitHub uses this for secondary rate limits
+	if retryAfter := headers.Get(headerRetryAfter); retryAfter != "" {
+		if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds > 0 {
+			duration := time.Duration(seconds) * time.Second
+			apiErr.RetryAfter = &duration
+		}
+	}
+
+	// Parse X-RateLimit-Reset header (Unix timestamp)
+	// GitHub uses this for primary rate limits
+	if resetStr := headers.Get(headerRateLimitReset); resetStr != "" {
+		if timestamp, err := strconv.ParseInt(resetStr, 10, 64); err == nil {
+			resetTime := time.Unix(timestamp, 0)
+			apiErr.RateLimitReset = &resetTime
+		}
+	}
+
+	return apiErr
+}
 
 // clientImpl wraps calls to the GitHub API for interacting with the Notifications API.
 type clientImpl struct {
@@ -334,6 +368,8 @@ func (c *clientImpl) FetchNotifications(
 }
 
 // FetchSubjectRaw retrieves the raw JSON payload for a notification subject.
+// On error, it returns an *APIError that may contain retry timing information
+// from the Retry-After or X-RateLimit-Reset headers.
 func (c *clientImpl) FetchSubjectRaw(
 	ctx context.Context,
 	subjectURL string,
@@ -368,7 +404,8 @@ func (c *clientImpl) FetchSubjectRaw(
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("github: subject status %d: %s", resp.StatusCode, string(body))
+		// Return a structured APIError with retry information from headers
+		return nil, newAPIError(resp.StatusCode, resp.Header, body)
 	}
 
 	var raw json.RawMessage

--- a/backend/internal/github/client_test.go
+++ b/backend/internal/github/client_test.go
@@ -18,6 +18,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -846,7 +847,7 @@ func TestFetchSubjectRaw(t *testing.T) {
 			serverStatus:   http.StatusNotFound,
 			serverResponse: `{"message": "Not Found"}`,
 			wantErr:        true,
-			errContains:    "subject status 404",
+			errContains:    "API status 404",
 		},
 		{
 			name:           "server error (500)",
@@ -854,7 +855,7 @@ func TestFetchSubjectRaw(t *testing.T) {
 			serverStatus:   http.StatusInternalServerError,
 			serverResponse: `{"message": "Server Error"}`,
 			wantErr:        true,
-			errContains:    "subject status 500",
+			errContains:    "API status 500",
 		},
 		{
 			name:           "invalid JSON response",
@@ -901,6 +902,97 @@ func TestFetchSubjectRaw(t *testing.T) {
 				} else {
 					require.NotNil(t, raw)
 				}
+			}
+		})
+	}
+}
+
+func TestFetchSubjectRaw_RetryHeaders(t *testing.T) {
+	tests := []struct {
+		name                 string
+		statusCode           int
+		retryAfterHeader     string
+		rateLimitReset       string
+		expectRetryAfter     bool
+		expectRateLimitReset bool
+		expectedSeconds      int
+	}{
+		{
+			name:             "429 with Retry-After header",
+			statusCode:       http.StatusTooManyRequests,
+			retryAfterHeader: "60",
+			expectRetryAfter: true,
+			expectedSeconds:  60,
+		},
+		{
+			name:                 "403 with X-RateLimit-Reset header",
+			statusCode:           http.StatusForbidden,
+			rateLimitReset:       "", // Will be set dynamically
+			expectRateLimitReset: true,
+		},
+		{
+			name:                 "500 without retry headers",
+			statusCode:           http.StatusInternalServerError,
+			expectRetryAfter:     false,
+			expectRateLimitReset: false,
+		},
+		{
+			name:             "429 with both headers prefers Retry-After",
+			statusCode:       http.StatusTooManyRequests,
+			retryAfterHeader: "30",
+			rateLimitReset:   "", // Will be set dynamically
+			expectRetryAfter: true,
+			expectedSeconds:  30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			futureReset := time.Now().Add(2 * time.Minute).Unix()
+
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					if tt.retryAfterHeader != "" {
+						w.Header().Set("Retry-After", tt.retryAfterHeader)
+					}
+					if tt.expectRateLimitReset ||
+						tt.name == "429 with both headers prefers Retry-After" {
+						w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", futureReset))
+					}
+					w.WriteHeader(tt.statusCode)
+					_, err := w.Write([]byte(`{"message": "error"}`))
+					assert.NoError(t, err)
+				}),
+			)
+			defer server.Close()
+
+			client := newTestClient(server.URL)
+			client.token = testToken
+
+			_, err := client.FetchSubjectRaw(context.Background(), server.URL+"/test")
+			require.Error(t, err)
+
+			// Verify it's an APIError with the expected retry info
+			var apiErr *APIError
+			require.True(t, errors.As(err, &apiErr), "error should be an APIError")
+			require.Equal(t, tt.statusCode, apiErr.StatusCode)
+
+			if tt.expectRetryAfter {
+				require.NotNil(t, apiErr.RetryAfter, "RetryAfter should be set")
+				require.Equal(t, time.Duration(tt.expectedSeconds)*time.Second, *apiErr.RetryAfter)
+			}
+
+			if tt.expectRateLimitReset {
+				require.NotNil(t, apiErr.RateLimitReset, "RateLimitReset should be set")
+				require.True(t, apiErr.RateLimitReset.After(time.Now()),
+					"RateLimitReset should be in the future")
+			}
+
+			// Verify GetRetryDelay works
+			delay := apiErr.GetRetryDelay()
+			if tt.expectRetryAfter || tt.expectRateLimitReset {
+				require.NotNil(t, delay, "GetRetryDelay should return a value")
+				require.True(t, *delay > 0, "delay should be positive")
 			}
 		})
 	}

--- a/backend/internal/github/errors.go
+++ b/backend/internal/github/errors.go
@@ -17,12 +17,64 @@ package github
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
+
+// APIError represents an error from the GitHub API with optional retry information.
+// It captures response headers that indicate when the client should retry.
+type APIError struct {
+	StatusCode     int            // HTTP status code
+	Message        string         // Error message from response body
+	RetryAfter     *time.Duration // Parsed from Retry-After header (seconds to wait)
+	RateLimitReset *time.Time     // Parsed from x-ratelimit-reset header (UTC timestamp)
+}
+
+// Error implements the error interface.
+func (e *APIError) Error() string {
+	return fmt.Sprintf("github: API status %d: %s", e.StatusCode, e.Message)
+}
+
+// GetRetryDelay returns the recommended duration to wait before retrying.
+// It prefers RetryAfter if set, otherwise calculates from RateLimitReset.
+// Returns nil if no retry information is available.
+func (e *APIError) GetRetryDelay() *time.Duration {
+	if e.RetryAfter != nil {
+		return e.RetryAfter
+	}
+	if e.RateLimitReset != nil {
+		delay := time.Until(*e.RateLimitReset)
+		if delay > 0 {
+			return &delay
+		}
+	}
+	return nil
+}
+
+// IsRateLimitError returns true if this is a rate limit error (429 or 403 with rate limit).
+func (e *APIError) IsRateLimitError() bool {
+	return e.StatusCode == 429 || (e.StatusCode == 403 && e.RateLimitReset != nil)
+}
+
+// IsServerError returns true if this is a server error (5xx).
+func (e *APIError) IsServerError() bool {
+	return e.StatusCode >= 500 && e.StatusCode < 600
+}
+
+// GetRetryDelayFromError extracts the retry delay from an error if it's an APIError.
+// Returns nil if the error is not an APIError or has no retry information.
+func GetRetryDelayFromError(err error) *time.Duration {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.GetRetryDelay()
+	}
+	return nil
+}
 
 // IsRetriableError determines if an error from GitHub API calls should be retried.
 // Returns true for transient errors that might succeed on retry:
@@ -30,12 +82,18 @@ import (
 // - HTTP 429 (rate limit)
 // - HTTP 5xx (server errors)
 // Returns false for permanent errors that won't succeed on retry:
-// - HTTP 403 (forbidden - org restrictions)
+// - HTTP 403 (forbidden - org restrictions, unless rate limited)
 // - HTTP 404 (not found - deleted PR/issue)
 // - HTTP 401 (unauthorized - auth issues)
 func IsRetriableError(err error) bool {
 	if err == nil {
 		return false
+	}
+
+	// Check if it's our structured APIError type
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return isRetriableStatusCode(apiErr.StatusCode, apiErr.RateLimitReset != nil)
 	}
 
 	// Check for network errors
@@ -65,8 +123,8 @@ func IsRetriableError(err error) bool {
 		return IsRetriableError(urlErr.Err)
 	}
 
-	// Parse error message for HTTP status codes
-	// FetchSubjectRaw returns: "github: subject status %d: %s"
+	// Parse error message for HTTP status codes (legacy path for non-APIError errors)
+	// Format: "github: API status %d: %s" or similar patterns containing "status <code>"
 	errStr := err.Error()
 
 	// Look for "status" followed by a number
@@ -91,13 +149,21 @@ func IsRetriableError(err error) bool {
 		return true // Can't parse status code, assume retriable
 	}
 
-	// Classify based on status code
+	return isRetriableStatusCode(statusCode, false)
+}
+
+// isRetriableStatusCode determines if an HTTP status code indicates a retriable error.
+// The isRateLimited parameter indicates if rate limit headers were present (for 403 responses).
+func isRetriableStatusCode(statusCode int, isRateLimited bool) bool {
 	switch statusCode {
 	case 429: // Rate limit - definitely retriable
 		return true
 	case 500, 502, 503, 504: // Server errors - retriable
 		return true
-	case 403, 404, 401: // Permanent errors - not retriable
+	case 403:
+		// 403 is retriable if it's due to rate limiting, otherwise permanent
+		return isRateLimited
+	case 404, 401: // Permanent errors - not retriable
 		return false
 	default:
 		// Unknown status code - be conservative and retry

--- a/backend/internal/github/errors_test.go
+++ b/backend/internal/github/errors_test.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -160,3 +161,231 @@ type timeoutError struct{}
 func (e *timeoutError) Error() string   { return "timeout" }
 func (e *timeoutError) Timeout() bool   { return true }
 func (e *timeoutError) Temporary() bool { return false }
+
+func TestAPIError_Error(t *testing.T) {
+	err := &APIError{
+		StatusCode: 429,
+		Message:    "rate limit exceeded",
+	}
+	require.Equal(t, "github: API status 429: rate limit exceeded", err.Error())
+}
+
+func TestAPIError_GetRetryDelay(t *testing.T) {
+	t.Run("prefers RetryAfter when set", func(t *testing.T) {
+		// Use a far-future RateLimitReset to avoid timing sensitivity
+		futureReset := time.Now().Add(10 * time.Minute)
+		err := &APIError{
+			StatusCode:     429,
+			Message:        "rate limited",
+			RetryAfter:     durationPtr(60 * time.Second),
+			RateLimitReset: &futureReset,
+		}
+		result := err.GetRetryDelay()
+		require.NotNil(t, result)
+		require.Equal(t, 60*time.Second, *result)
+	})
+
+	t.Run("uses RateLimitReset when RetryAfter not set", func(t *testing.T) {
+		// Use a generous buffer to avoid timing sensitivity in slow CI
+		futureReset := time.Now().Add(5 * time.Minute)
+		err := &APIError{
+			StatusCode:     429,
+			Message:        "rate limited",
+			RateLimitReset: &futureReset,
+		}
+		result := err.GetRetryDelay()
+		require.NotNil(t, result)
+		// Allow for up to 10 seconds of test execution time
+		require.True(t, *result > 4*time.Minute+50*time.Second && *result <= 5*time.Minute,
+			"expected delay ~5m, got %v", *result)
+	})
+
+	t.Run("returns nil when neither set", func(t *testing.T) {
+		err := &APIError{
+			StatusCode: 500,
+			Message:    "server error",
+		}
+		require.Nil(t, err.GetRetryDelay())
+	})
+
+	t.Run("returns nil when RateLimitReset is in the past", func(t *testing.T) {
+		// Use a clearly past time to avoid boundary issues
+		pastReset := time.Now().Add(-5 * time.Minute)
+		err := &APIError{
+			StatusCode:     429,
+			Message:        "rate limited",
+			RateLimitReset: &pastReset,
+		}
+		require.Nil(t, err.GetRetryDelay())
+	})
+}
+
+func TestAPIError_IsRateLimitError(t *testing.T) {
+	// Fixed time for tests that only check nil vs non-nil
+	anyTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		err      *APIError
+		expected bool
+	}{
+		{
+			name:     "429 is rate limit error",
+			err:      &APIError{StatusCode: 429},
+			expected: true,
+		},
+		{
+			name:     "403 with RateLimitReset is rate limit error",
+			err:      &APIError{StatusCode: 403, RateLimitReset: &anyTime},
+			expected: true,
+		},
+		{
+			name:     "403 without RateLimitReset is not rate limit error",
+			err:      &APIError{StatusCode: 403},
+			expected: false,
+		},
+		{
+			name:     "500 is not rate limit error",
+			err:      &APIError{StatusCode: 500},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.err.IsRateLimitError())
+		})
+	}
+}
+
+func TestAPIError_IsServerError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *APIError
+		expected bool
+	}{
+		{name: "500 is server error", err: &APIError{StatusCode: 500}, expected: true},
+		{name: "502 is server error", err: &APIError{StatusCode: 502}, expected: true},
+		{name: "503 is server error", err: &APIError{StatusCode: 503}, expected: true},
+		{name: "504 is server error", err: &APIError{StatusCode: 504}, expected: true},
+		{name: "599 is server error", err: &APIError{StatusCode: 599}, expected: true},
+		{name: "400 is not server error", err: &APIError{StatusCode: 400}, expected: false},
+		{name: "429 is not server error", err: &APIError{StatusCode: 429}, expected: false},
+		{name: "200 is not server error", err: &APIError{StatusCode: 200}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.err.IsServerError())
+		})
+	}
+}
+
+func TestGetRetryDelayFromError(t *testing.T) {
+	retryDuration := 30 * time.Second
+
+	tests := []struct {
+		name          string
+		err           error
+		expectNil     bool
+		expectSeconds int
+	}{
+		{
+			name:      "nil error returns nil",
+			err:       nil,
+			expectNil: true,
+		},
+		{
+			name:      "non-APIError returns nil",
+			err:       errors.New("some error"),
+			expectNil: true,
+		},
+		{
+			name: "APIError with RetryAfter returns delay",
+			err: &APIError{
+				StatusCode: 429,
+				RetryAfter: &retryDuration,
+			},
+			expectNil:     false,
+			expectSeconds: 30,
+		},
+		{
+			name: "wrapped APIError returns delay",
+			err: errors.Join(
+				errors.New("failed to fetch"),
+				&APIError{StatusCode: 429, RetryAfter: &retryDuration},
+			),
+			expectNil:     false,
+			expectSeconds: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetRetryDelayFromError(tt.err)
+			if tt.expectNil {
+				require.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				require.Equal(t, time.Duration(tt.expectSeconds)*time.Second, *result)
+			}
+		})
+	}
+}
+
+func TestIsRetriableError_WithAPIError(t *testing.T) {
+	// Fixed time for tests that only check nil vs non-nil
+	anyTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		err      *APIError
+		expected bool
+	}{
+		{
+			name:     "APIError 429 is retriable",
+			err:      &APIError{StatusCode: 429, Message: "rate limited"},
+			expected: true,
+		},
+		{
+			name:     "APIError 500 is retriable",
+			err:      &APIError{StatusCode: 500, Message: "server error"},
+			expected: true,
+		},
+		{
+			name:     "APIError 502 is retriable",
+			err:      &APIError{StatusCode: 502, Message: "bad gateway"},
+			expected: true,
+		},
+		{
+			name:     "APIError 403 with RateLimitReset is retriable",
+			err:      &APIError{StatusCode: 403, Message: "rate limited", RateLimitReset: &anyTime},
+			expected: true,
+		},
+		{
+			name:     "APIError 403 without RateLimitReset is not retriable",
+			err:      &APIError{StatusCode: 403, Message: "forbidden"},
+			expected: false,
+		},
+		{
+			name:     "APIError 404 is not retriable",
+			err:      &APIError{StatusCode: 404, Message: "not found"},
+			expected: false,
+		},
+		{
+			name:     "APIError 401 is not retriable",
+			err:      &APIError{StatusCode: 401, Message: "unauthorized"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsRetriableError(tt.err))
+		})
+	}
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}

--- a/backend/internal/jobs/queue.go
+++ b/backend/internal/jobs/queue.go
@@ -21,10 +21,18 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
 	"time"
 
 	"github.com/octobud-hq/octobud/backend/internal/db"
 	"github.com/octobud-hq/octobud/backend/internal/db/sqlite"
+)
+
+// Jitter configuration for exponential backoff
+const (
+	// jitterFactor is the range of randomization applied to backoff.
+	// 0.5 means the actual delay will be between 50% and 150% of the base backoff.
+	jitterFactor = 0.5
 )
 
 // Queue names for different job types
@@ -84,6 +92,11 @@ type JobQueue interface {
 
 	// Nack marks a job as failed - will retry with backoff or dead-letter
 	Nack(ctx context.Context, jobID int64, err error) error
+
+	// NackWithDelay marks a job as failed with a minimum retry delay.
+	// This is useful when the server provides a Retry-After header.
+	// The actual delay will be max(minDelay, calculatedBackoff).
+	NackWithDelay(ctx context.Context, jobID int64, err error, minDelay time.Duration) error
 
 	// ResetStale reclaims jobs stuck in "processing" state (crashed workers)
 	ResetStale(ctx context.Context, timeout time.Duration) (int64, error)
@@ -178,6 +191,18 @@ func (q *SQLiteJobQueue) Ack(ctx context.Context, jobID int64) error {
 
 // Nack marks a job as failed - will retry with backoff or dead-letter
 func (q *SQLiteJobQueue) Nack(ctx context.Context, jobID int64, jobErr error) error {
+	return q.NackWithDelay(ctx, jobID, jobErr, 0)
+}
+
+// NackWithDelay marks a job as failed with an optional minimum retry delay.
+// If minDelay is provided (> 0), the actual delay will be max(minDelay, calculatedBackoff).
+// This is useful when the server provides a Retry-After header that should be respected.
+func (q *SQLiteJobQueue) NackWithDelay(
+	ctx context.Context,
+	jobID int64,
+	jobErr error,
+	minDelay time.Duration,
+) error {
 	// Retry all operations on SQLITE_BUSY - critical to ensure job state is updated
 	// If Nack fails, the job would be stuck in "processing" state until stale job cleanup
 
@@ -204,16 +229,15 @@ func (q *SQLiteJobQueue) Nack(ctx context.Context, jobID int64, jobErr error) er
 		})
 	}
 
-	// Calculate exponential backoff: 1s, 2s, 4s, 8s, 16s...
-	backoffSeconds := int(math.Pow(2, float64(job.Attempts-1)))
-	if backoffSeconds < 1 {
-		backoffSeconds = 1
-	}
-	if backoffSeconds > 300 { // Cap at 5 minutes
-		backoffSeconds = 300
+	// Calculate exponential backoff with jitter to prevent thundering herd
+	backoffDelay := calculateBackoffWithJitter(int(job.Attempts))
+
+	// Use the larger of calculated backoff or server-specified minimum delay
+	if minDelay > backoffDelay {
+		backoffDelay = minDelay
 	}
 
-	nextSchedule := time.Now().UTC().Add(time.Duration(backoffSeconds) * time.Second)
+	nextSchedule := time.Now().UTC().Add(backoffDelay)
 
 	return db.RetryVoidOnBusy(ctx, func() error {
 		return q.queries.NackJobRetry(ctx, sqlite.NackJobRetryParams{
@@ -222,6 +246,32 @@ func (q *SQLiteJobQueue) Nack(ctx context.Context, jobID int64, jobErr error) er
 			LastError:   errStr,
 		})
 	})
+}
+
+// calculateBackoffWithJitter computes an exponential backoff delay with random jitter.
+// Base formula: 2^attempts seconds, with ±50% jitter.
+// This prevents the thundering herd problem when multiple workers fail at the same time.
+func calculateBackoffWithJitter(attempts int) time.Duration {
+	// Base exponential backoff: 2s, 4s, 8s, 16s, 32s...
+	// Starting at 2s gives a reasonable initial delay for API failures.
+	baseBackoffSeconds := math.Pow(2, float64(attempts))
+	if baseBackoffSeconds < 2 {
+		baseBackoffSeconds = 2
+	}
+
+	// Cap at 5 minutes before applying jitter
+	const maxBackoffSeconds = 300.0
+	if baseBackoffSeconds > maxBackoffSeconds {
+		baseBackoffSeconds = maxBackoffSeconds
+	}
+
+	// Apply jitter: multiply by random factor between (1-jitterFactor) and (1+jitterFactor)
+	// This spreads retries across time to avoid synchronized retry storms
+	// #nosec G404 -- math/rand is sufficient for jitter; no security requirement
+	jitterMultiplier := 1.0 - jitterFactor + (rand.Float64() * 2 * jitterFactor)
+	backoffSeconds := baseBackoffSeconds * jitterMultiplier
+
+	return time.Duration(backoffSeconds * float64(time.Second))
 }
 
 // ResetStale reclaims jobs stuck in "processing" state

--- a/backend/internal/jobs/queue_test.go
+++ b/backend/internal/jobs/queue_test.go
@@ -274,3 +274,132 @@ func TestSQLiteJobQueue_QueueIsolation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("rule"), job.Payload)
 }
+
+func TestSQLiteJobQueue_NackWithDelay(t *testing.T) {
+	db := setupQueueTestDB(t)
+	queue := NewSQLiteJobQueue(db)
+	ctx := context.Background()
+
+	t.Run("uses minDelay when larger than calculated backoff", func(t *testing.T) {
+		jobID, err := queue.Enqueue(ctx, EnqueueParams{
+			Queue:       QueueProcessNotification,
+			Payload:     []byte("test-min-delay"),
+			MaxAttempts: 5,
+		})
+		require.NoError(t, err)
+
+		job, err := queue.Dequeue(ctx, QueueProcessNotification)
+		require.NoError(t, err)
+		require.Equal(t, jobID, job.ID)
+
+		// First attempt backoff would be ~2s (with jitter), so use a larger minDelay
+		minDelay := 60 * time.Second
+		err = queue.NackWithDelay(ctx, job.ID, errors.New("rate limited"), minDelay)
+		require.NoError(t, err)
+
+		// Verify the job is scheduled with at least the minDelay
+		var scheduledAt string
+		err = db.QueryRowContext(ctx, "SELECT scheduled_at FROM jobs WHERE id = ?", job.ID).
+			Scan(&scheduledAt)
+		require.NoError(t, err)
+
+		scheduled, err := time.Parse(time.RFC3339, scheduledAt)
+		require.NoError(t, err)
+
+		// Should be scheduled at least 55 seconds from now (allowing for test execution time)
+		require.True(t, scheduled.After(time.Now().Add(55*time.Second)),
+			"job should be scheduled at least 55s from now, but was scheduled for %v", scheduled)
+	})
+
+	t.Run("uses calculated backoff when larger than minDelay", func(t *testing.T) {
+		jobID, err := queue.Enqueue(ctx, EnqueueParams{
+			Queue:       QueueProcessNotification,
+			Payload:     []byte("test-calculated-backoff"),
+			MaxAttempts: 5,
+		})
+		require.NoError(t, err)
+
+		job, err := queue.Dequeue(ctx, QueueProcessNotification)
+		require.NoError(t, err)
+		require.Equal(t, jobID, job.ID)
+
+		// Use a very small minDelay that will be smaller than the calculated backoff
+		minDelay := 100 * time.Millisecond
+		err = queue.NackWithDelay(ctx, job.ID, errors.New("temporary error"), minDelay)
+		require.NoError(t, err)
+
+		// Verify the job is scheduled (with calculated backoff, not minDelay)
+		var scheduledAt string
+		err = db.QueryRowContext(ctx, "SELECT scheduled_at FROM jobs WHERE id = ?", job.ID).
+			Scan(&scheduledAt)
+		require.NoError(t, err)
+
+		scheduled, err := time.Parse(time.RFC3339, scheduledAt)
+		require.NoError(t, err)
+
+		// First attempt backoff should be around 1s-3s with jitter (base 2s ±50%)
+		// Should be more than 100ms (the minDelay)
+		delay := time.Until(scheduled)
+		require.True(t, delay > minDelay,
+			"delay should be greater than minDelay, got %v", delay)
+	})
+}
+
+func TestCalculateBackoffWithJitter(t *testing.T) {
+	t.Run("first attempt returns approximately 2 seconds with jitter", func(t *testing.T) {
+		// Run multiple times to verify jitter is applied
+		var results []time.Duration
+		for i := 0; i < 100; i++ {
+			results = append(results, calculateBackoffWithJitter(1))
+		}
+
+		// With jitterFactor = 0.5, base of 2s should give 1s to 3s range
+		for _, d := range results {
+			require.True(t, d >= 1*time.Second && d <= 3*time.Second,
+				"backoff %v should be between 1s and 3s", d)
+		}
+
+		// Verify there's variance (jitter is working)
+		allSame := true
+		for i := 1; i < len(results); i++ {
+			if results[i] != results[0] {
+				allSame = false
+				break
+			}
+		}
+		require.False(t, allSame, "expected jitter to produce different values")
+	})
+
+	t.Run("respects max cap of 300 seconds", func(t *testing.T) {
+		// Attempt 10 would normally give 2^10 = 1024 seconds base, but capped at 300s
+		for i := 0; i < 10; i++ {
+			d := calculateBackoffWithJitter(10)
+			// With jitterFactor = 0.5 and max of 300s, range is 150s to 450s
+			require.True(t, d <= 450*time.Second,
+				"backoff %v should not exceed 450s (300s * 1.5)", d)
+			require.True(t, d >= 150*time.Second,
+				"backoff %v should be at least 150s (300s * 0.5)", d)
+		}
+	})
+
+	t.Run("exponential growth", func(t *testing.T) {
+		// Calculate average for each attempt level
+		avgForAttempt := func(attempt int) time.Duration {
+			var total time.Duration
+			n := 100
+			for i := 0; i < n; i++ {
+				total += calculateBackoffWithJitter(attempt)
+			}
+			return total / time.Duration(n)
+		}
+
+		avg1 := avgForAttempt(1) // Base ~2s
+		avg2 := avgForAttempt(2) // Base ~4s
+		avg3 := avgForAttempt(3) // Base ~8s
+
+		// Each level should approximately double
+		// Allow for jitter variance
+		require.True(t, avg2 > avg1, "avg2 (%v) should be > avg1 (%v)", avg2, avg1)
+		require.True(t, avg3 > avg2, "avg3 (%v) should be > avg2 (%v)", avg3, avg2)
+	})
+}

--- a/backend/internal/jobs/sqlite_scheduler.go
+++ b/backend/internal/jobs/sqlite_scheduler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/octobud-hq/octobud/backend/internal/core/auth"
 	"github.com/octobud-hq/octobud/backend/internal/core/update"
 	"github.com/octobud-hq/octobud/backend/internal/db"
+	"github.com/octobud-hq/octobud/backend/internal/github"
 	"github.com/octobud-hq/octobud/backend/internal/jobs/handlers"
 	coresync "github.com/octobud-hq/octobud/backend/internal/sync"
 )
@@ -441,13 +442,21 @@ func (s *SQLiteScheduler) notificationWorker(ctx context.Context, workerID int) 
 
 		err = s.processNotificationHandler.Handle(ctx, userID, job.Payload)
 		if err != nil {
-			s.logger.Warn("notification job failed",
+			// Extract server-specified retry delay if present (e.g., from Retry-After header)
+			var minDelay time.Duration
+			fields := []zap.Field{
 				zap.Int64("jobID", job.ID),
 				zap.Int("attempt", job.Attempts),
-				zap.Error(err))
+				zap.Error(err),
+			}
+			if retryDelay := github.GetRetryDelayFromError(err); retryDelay != nil {
+				minDelay = *retryDelay
+				fields = append(fields, zap.Duration("serverRetryDelay", minDelay))
+			}
+			s.logger.Warn("notification job failed", fields...)
 
-			// Nack will either retry or dead-letter the job
-			if nackErr := s.jobQueue.Nack(ctx, job.ID, err); nackErr != nil {
+			// NackWithDelay uses max(minDelay, calculatedBackoff); 0 means use backoff only
+			if nackErr := s.jobQueue.NackWithDelay(ctx, job.ID, err, minDelay); nackErr != nil {
 				s.logger.Error("failed to nack job", zap.Int64("jobID", job.ID), zap.Error(nackErr))
 			}
 		} else {

--- a/backend/internal/sync/sync.go
+++ b/backend/internal/sync/sync.go
@@ -312,10 +312,15 @@ func (s *Service) ProcessNotification(
 	} else if err != nil {
 		// Check if error is retriable - if so, return error to trigger job retry
 		if github.IsRetriableError(err) {
-			s.logger.Warn("failed to fetch subject data (retriable error, will retry)",
+			fields := []zap.Field{
 				zap.String("githubID", thread.ID),
 				zap.String("subjectURL", thread.Subject.URL),
-				zap.Error(err))
+				zap.Error(err),
+			}
+			if retryDelay := github.GetRetryDelayFromError(err); retryDelay != nil {
+				fields = append(fields, zap.Duration("serverRetryAfter", *retryDelay))
+			}
+			s.logger.Warn("failed to fetch subject data (retriable error, will retry)", fields...)
 			return errors.Join(ErrFailedToFetchSubject, err)
 		}
 		// Non-retriable error - log but don't fail, continue without subject data


### PR DESCRIPTION
## Description

This should alleviate unnecessary pressure Octobud sync can put on GitHub's API when there are issues:

- Longer backoff intervals with jitter.
- Respect rate limit headers

## Motivation

Observed overly aggressive retrying when GitHub is returning 500s.

Fixes #

## Changes

<!-- List the main changes in this PR -->

- Longer backoff intervals with jitter.
- Respect rate limit headers

## Testing

<!-- How did you test these changes? -->

- [x] Ran backend tests (`make test-backend` or `cd backend && make test`)
- [X] Ran frontend tests (`make test-frontend` or `cd frontend && npm test`)
- [X] Ran integration tests (`make test-integration`)
- [X] Manual testing
  - [X] Tested on macOS
  - [ ] Tested on Linux (if applicable)
  - [ ] Tested on Windows (if applicable)

## Screenshots

<!-- If this is a UI change, include screenshots -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Tests added/updated as needed
- [x] Documentation updated if needed
- [x] Self-reviewed the code
- [x] No console.log/fmt.Println left in code
- [x] No secrets or sensitive data in code
- [x] CHANGELOG.md updated (if applicable)
